### PR TITLE
fix: remove unnecessary destructuring and fix incorrect property access in ExceptionDetailsComponent

### DIFF
--- a/packages/node-telescope-frontend/src/components/ExceptionDetailComponent.tsx
+++ b/packages/node-telescope-frontend/src/components/ExceptionDetailComponent.tsx
@@ -73,19 +73,17 @@ const CodeEditorStyle: React.FC<{
 };
 
 const ExceptionDetailsComponent: React.FC<{ exception: any }> = ({ exception }) => {
-  const { exception: exceptionData } = exception;
-
   const renderCodeContext = () => {
-    if (!exceptionData.context) return null;
+    if (!exception.context) return null;
 
-    const lineNumbers = Object.keys(exceptionData.context).map(Number);
+    const lineNumbers = Object.keys(exception.context).map(Number);
     const startLine = Math.min(...lineNumbers);
-    const code = Object.entries(exceptionData.context)
+    const code = Object.entries(exception.context)
       .sort(([a], [b]) => parseInt(a) - parseInt(b))
       .map(([_, line]) => line)
       .join('\n');
 
-    return <CodeEditorStyle code={code} errorLine={exceptionData.line} startLine={startLine} />;
+    return <CodeEditorStyle code={code} errorLine={exception.line} startLine={startLine} />;
   };
 
   return (
@@ -101,28 +99,28 @@ const ExceptionDetailsComponent: React.FC<{ exception: any }> = ({ exception }) 
           <Descriptions.Item label="Type">
             <BugOutlined /> {exception.type}
           </Descriptions.Item>
-          <Descriptions.Item label="Class">{exceptionData.class}</Descriptions.Item>
+          <Descriptions.Item label="Class">{exception.class}</Descriptions.Item>
         </Descriptions>
       </Card>
 
       <Card style={{ marginTop: 16 }}>
         <Title level={4}>Exception Message</Title>
         <Paragraph>
-          <Text strong>{exceptionData.message}</Text>
+          <Text strong>{exception.message}</Text>
         </Paragraph>
-        {exceptionData.file && (
+        {exception.file && (
           <Paragraph>
-            <FileOutlined /> {exceptionData.file}
-            {exceptionData.line && (
+            <FileOutlined /> {exception.file}
+            {exception.line && (
               <Tag color="red" style={{ marginLeft: 8 }}>
-                Line {exceptionData.line}
+                Line {exception.line}
               </Tag>
             )}
           </Paragraph>
         )}
       </Card>
 
-      {exceptionData.context && (
+      {exception.context && (
         <Card style={{ marginTop: 16 }}>
           <Title level={4}>Code Context</Title>
           {renderCodeContext()}
@@ -132,7 +130,7 @@ const ExceptionDetailsComponent: React.FC<{ exception: any }> = ({ exception }) 
       <Collapse style={{ marginTop: 16 }}>
         <Panel header="Stack Trace" key="1">
           <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-            {exceptionData.stack}
+            {exception.stack}
           </pre>
         </Panel>
       </Collapse>


### PR DESCRIPTION
# Pull Request

## Description

This change removes redundant destructuring of the exception prop and addresses an issue where the exception object was incorrectly accessed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### To Reproduce the Issue:
* Build the project.
* Navigate to the `telescope/exceptions/:exceptionId` route, ensuring that `exceptionId` is a valid identifier.

### To Verify the Fix:
  * **Test Case 1: Base Page Loading**
    * Navigate to the `telescope/exceptions` page.
    * Verify that the page loads correctly without errors.
  * **Test Case 2: Valid Exception ID**
    * Navigate to `telescope/exceptions/:exceptionId` with a valid exception ID.
    * Ensure the correct exception details are displayed.
  * **Test Case 3: Invalid Exception ID**
    * Navigate to `telescope/exceptions/:exceptionId` with an invalid exception ID.
    * Verify that appropriate error handling or a default view is displayed.

## Checklist:

Before submitting your PR, please review the following checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

![ComponentLoadError](https://github.com/user-attachments/assets/0a728bf7-1500-4330-ac18-0697b46580c3)
![image](https://github.com/user-attachments/assets/9b4663c3-679e-437f-8bfa-26b68ee9aec4)
